### PR TITLE
properties => statement_constraints?

### DIFF
--- a/dctap/inspect.py
+++ b/dctap/inspect.py
@@ -43,7 +43,7 @@ def tapshapes_to_dicts(tapshapes_list, verbose=False):
         tapshape_dict = asdict(tapshape_obj)
         # Removing 'start' for now, not yet part of official DCTAP spec.
         tapshape_dict.pop('start')
-        tapshape_dict['properties'] = tapshape_dict.pop('sc_list')
+        tapshape_dict['statement_constraints'] = tapshape_dict.pop('sc_list')
         shape_list.append(tapshape_dict)
 
     return dict_output


### PR DESCRIPTION
For consistency of terminology, I'd prefer to avoid "properties", which are things in the data but not in a shape.

Unfortunately, I cannot think of anything much shorter than `statement_constraints` (21 letters, compared to 10 for `properties`):
- `sc` and `sconstraints` are too cryptic
- `statconstraints` (15 letters) could be a compromise.