### PR TITLE
Fix for Pylint R1710

### DIFF
--- a/dctap/utils.py
+++ b/dctap/utils.py
@@ -25,6 +25,7 @@ def is_uri_or_prefixed_uri(uri):
         return True
     if re.match("[A-Za-z0-9_]*:[A-Za-z0-9_]*", uri):  # looks like prefixed URI
         return True
+    return False
 
 
 def expand_uri_prefixes(shapes_dict=None, config_dict=None):


### PR DESCRIPTION
This function is not returning anything default, so a default `false` is safe and will solve R1710 (inconsistent-return-statements). This commit fixes #8 and #7